### PR TITLE
Reference et doy branch into master

### DIFF
--- a/examples/collection_interpolate_error_testing.ipynb
+++ b/examples/collection_interpolate_error_testing.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenET SSEBop\n",
+    "## Collection \"Interpolate\" Examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import pprint\n",
+    "\n",
+    "import ee\n",
+    "import pandas as pd\n",
+    "\n",
+    "from IPython.display import Image\n",
+    "import openet.ssebop as model\n",
+    "\n",
+    "ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndvi_palette = ['#EFE7E1', '#003300']\n",
+    "et_palette = [\n",
+    "    'DEC29B', 'E6CDA1', 'EDD9A6', 'F5E4A9', 'FFF4AD', 'C3E683', '6BCC5C', \n",
+    "    '3BB369', '20998F', '1C8691', '16678A', '114982', '0B2C7A']\n",
+    "\n",
+    "image_size = 768\n",
+    "landsat_cs = 30"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Input parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collections = ['LANDSAT/LC08/C01/T1_TOA']\n",
+    "\n",
+    "# et_reference_source = 'projects/climate-engine/cimis/daily'\n",
+    "et_reference_source = 'projects/usgs-ssebop/pet/gridmet_median_v1'\n",
+    "et_reference_band = 'etr'\n",
+    "et_reference_factor = 1.0\n",
+    "et_reference_resample = 'nearest'\n",
+    "et_reference_date_type = 'DOY'\n",
+    "# et_reference_source = 'IDAHO_EPSCOR/GRIDMET'\n",
+    "# et_reference_band = 'etr'\n",
+    "# et_reference_factor = 0.85\n",
+    "# et_reference_resample = 'nearest'\n",
+    "\n",
+    "# Date range you want to aggregate ET over\n",
+    "# End date is inclusive (like filterDate() calls)\n",
+    "start_date = '2017-07-01'\n",
+    "end_date = '2017-08-01'\n",
+    "\n",
+    "# Only keep images with an average cloud cover less than\n",
+    "# Cloud cover filter parameter is not being passed in (yet)\n",
+    "cloud_cover = 70\n",
+    "\n",
+    "# Number of extra days (at start and end) to include in interpolation\n",
+    "interp_days = 32\n",
+    "# Interpolation method - currently only LINEAR is supported\n",
+    "interp_method = 'LINEAR'\n",
+    "\n",
+    "test_xy = [-121.5265, 38.7399]\n",
+    "test_point = ee.Geometry.Point(test_xy)\n",
+    "\n",
+    "# study_area = ee.Geometry.Rectangle(-122.00, 38.60, -121.00, 39.0)\n",
+    "study_area = ee.Geometry.Rectangle(\n",
+    "    test_xy[0] - 0.08, test_xy[1] - 0.04, \n",
+    "    test_xy[0] + 0.08, test_xy[1] + 0.04)\n",
+    "study_region = study_area.bounds(1, 'EPSG:4326')\n",
+    "study_crs = 'EPSG:32610'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build the collection object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_obj = model.Collection(\n",
+    "    collections=collections,\n",
+    "    et_reference_source=et_reference_source, \n",
+    "    et_reference_band=et_reference_band,\n",
+    "    et_reference_factor=et_reference_factor,\n",
+    "    et_reference_resample=et_reference_resample,\n",
+    "    et_reference_date_type = et_reference_date_type,\n",
+    "    start_date=start_date,\n",
+    "    end_date=end_date,\n",
+    "    geometry=test_point,\n",
+    "    cloud_cover_max=70,\n",
+    "    # filter_args={},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This isn't returning the images used for interpolation.  Should it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['LANDSAT/LC08/C01/T1_TOA/LC08_044033_20170716']\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint.pprint(model_obj.get_image_ids())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_region_df(info):\n",
+    "    \"\"\"Convert the output of getRegions to a pandas dataframe\"\"\"\n",
+    "    col_dict = {}\n",
+    "    info_dict = {}\n",
+    "    for i, k in enumerate(info[0][4:]):\n",
+    "        col_dict[k] = i+4\n",
+    "        info_dict[k] = {}\n",
+    "        \n",
+    "    for row in info[1:]:\n",
+    "        date = datetime.datetime.utcfromtimestamp(row[3] / 1000.0).strftime('%Y-%m-%d')\n",
+    "        for k, v in col_dict.items():\n",
+    "            info_dict[k][date] = row[col_dict[k]]\n",
+    "            \n",
+    "    return pd.DataFrame.from_dict(info_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interpolate Daily ET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "EEException",
+     "evalue": "ImageCollection.getRegion: No bands in collection.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mHttpError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36m_execute_cloud_call\u001b[1;34m(call, num_retries)\u001b[0m\n\u001b[0;32m    333\u001b[0m   \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 334\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    335\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mgoogleapiclient\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mHttpError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\googleapiclient\\_helpers.py\u001b[0m in \u001b[0;36mpositional_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    133\u001b[0m                     \u001b[0mlogger\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwarning\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 134\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0mwrapped\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    135\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\googleapiclient\\http.py\u001b[0m in \u001b[0;36mexecute\u001b[1;34m(self, http, num_retries)\u001b[0m\n\u001b[0;32m    914\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mresp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstatus\u001b[0m \u001b[1;33m>=\u001b[0m \u001b[1;36m300\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 915\u001b[1;33m             \u001b[1;32mraise\u001b[0m \u001b[0mHttpError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcontent\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0muri\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0muri\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    916\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpostproc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcontent\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mHttpError\u001b[0m: <HttpError 400 when requesting https://earthengine.googleapis.com/v1alpha/projects/earthengine-legacy/value:compute?prettyPrint=false&alt=json returned \"ImageCollection.getRegion: No bands in collection.\". Details: \"ImageCollection.getRegion: No bands in collection.\">",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[1;31mEEException\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-15-b8ca32fbb042>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      8\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      9\u001b[0m \u001b[1;31m# # This raises an EE memory error\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 10\u001b[1;33m \u001b[0mdaily_df\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mget_region_df\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdaily_coll\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgetRegion\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtest_point\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mscale\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m30\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgetInfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     11\u001b[0m \u001b[0mpprint\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdaily_df\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     12\u001b[0m \u001b[1;31m# print('')\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\computedobject.py\u001b[0m in \u001b[0;36mgetInfo\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     96\u001b[0m       \u001b[0mThe\u001b[0m \u001b[0mobject\u001b[0m \u001b[0mcan\u001b[0m \u001b[0mevaluate\u001b[0m \u001b[0mto\u001b[0m \u001b[0manything\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     97\u001b[0m     \"\"\"\n\u001b[1;32m---> 98\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcomputeValue\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     99\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    100\u001b[0m   \u001b[1;32mdef\u001b[0m \u001b[0mencode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mencoder\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36mcomputeValue\u001b[1;34m(obj)\u001b[0m\n\u001b[0;32m    674\u001b[0m           \u001b[0mbody\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m{\u001b[0m\u001b[1;34m'expression'\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mserializer\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mencode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mfor_cloud_api\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    675\u001b[0m           \u001b[0mproject\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0m_get_projects_path\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 676\u001b[1;33m           prettyPrint=False))['result']\n\u001b[0m\u001b[0;32m    677\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    678\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36m_execute_cloud_call\u001b[1;34m(call, num_retries)\u001b[0m\n\u001b[0;32m    334\u001b[0m     \u001b[1;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    335\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mgoogleapiclient\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mHttpError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 336\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0m_translate_cloud_exception\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0me\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    337\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    338\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mEEException\u001b[0m: ImageCollection.getRegion: No bands in collection."
+     ]
+    }
+   ],
+   "source": [
+    "daily_coll = model_obj.interpolate(\n",
+    "    t_interval='daily', \n",
+    "#     variables=['et', 'et_reference', 'et_fraction'], \n",
+    "    variables= ['et_reference'],\n",
+    "    interp_method=interp_method,\n",
+    "    interp_days=interp_days,\n",
+    ")\n",
+    "\n",
+    "# # This raises an EE memory error\n",
+    "daily_df = get_region_df(daily_coll.getRegion(test_point, scale=30).getInfo())\n",
+    "pprint.pprint(daily_df)\n",
+    "# print('')\n",
+    "# pprint.pprint(daily_df[['et', 'et_reference']].sum())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interpolate Monthly ET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_coll = model_obj.interpolate(\n",
+    "    t_interval='monthly', \n",
+    "#     variables=['et', 'et_reference', 'et_fraction'], \n",
+    "    variables= ['et_reference'],\n",
+    "    interp_method=interp_method,\n",
+    "    interp_days=interp_days,\n",
+    ")\n",
+    "monthly_df = get_region_df(monthly_coll.getRegion(test_point, scale=30).getInfo())\n",
+    "pprint.pprint(monthly_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sum of Daily ET (for one month)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# image_url = ee.Image(daily_coll.select(['et']).sum())\\\n",
+    "#     .reproject(crs=study_crs, scale=100)\\\n",
+    "#     .getThumbURL({'min': 0.0, 'max': 300, 'palette': et_palette, \n",
+    "#                   'region': study_region, 'dimensions': image_size})\n",
+    "# Image(image_url, embed=True, format='png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly ET (for one month)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# image_url = ee.Image(monthly_coll.select(['et']).sum())\\\n",
+    "#     .reproject(crs=study_crs, scale=100)\\\n",
+    "#     .getThumbURL({'min': 0.0, 'max': 350, 'palette': et_palette, \n",
+    "#                   'region': study_region, 'dimensions': image_size})\n",
+    "# Image(image_url, embed=True, format='png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly ETr (for one month)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_url = ee.Image(monthly_coll.select(['et_reference']).sum())\\\n",
+    "    .reproject(crs=study_crs, scale=100)\\\n",
+    "    .getThumbURL({'min': 0.0, 'max': 350, 'palette': et_palette, \n",
+    "                  'region': study_region, 'dimensions': image_size})\n",
+    "Image(image_url, embed=True, format='png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/collection_interpolate_error_testing.ipynb
+++ b/examples/collection_interpolate_error_testing.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,6 +116,7 @@
     "    end_date=end_date,\n",
     "    geometry=test_point,\n",
     "    cloud_cover_max=70,\n",
+    "    model_args={'tcorr_source': 0.99}\n",
     "    # filter_args={},\n",
     ")"
    ]
@@ -129,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -146,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,27 +176,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
-     "ename": "EEException",
-     "evalue": "ImageCollection.getRegion: No bands in collection.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mHttpError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36m_execute_cloud_call\u001b[1;34m(call, num_retries)\u001b[0m\n\u001b[0;32m    333\u001b[0m   \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 334\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    335\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mgoogleapiclient\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mHttpError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\googleapiclient\\_helpers.py\u001b[0m in \u001b[0;36mpositional_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    133\u001b[0m                     \u001b[0mlogger\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mwarning\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 134\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0mwrapped\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    135\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\googleapiclient\\http.py\u001b[0m in \u001b[0;36mexecute\u001b[1;34m(self, http, num_retries)\u001b[0m\n\u001b[0;32m    914\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mresp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstatus\u001b[0m \u001b[1;33m>=\u001b[0m \u001b[1;36m300\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 915\u001b[1;33m             \u001b[1;32mraise\u001b[0m \u001b[0mHttpError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcontent\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0muri\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0muri\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    916\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpostproc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcontent\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mHttpError\u001b[0m: <HttpError 400 when requesting https://earthengine.googleapis.com/v1alpha/projects/earthengine-legacy/value:compute?prettyPrint=false&alt=json returned \"ImageCollection.getRegion: No bands in collection.\". Details: \"ImageCollection.getRegion: No bands in collection.\">",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[1;31mEEException\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-15-b8ca32fbb042>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      8\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      9\u001b[0m \u001b[1;31m# # This raises an EE memory error\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 10\u001b[1;33m \u001b[0mdaily_df\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mget_region_df\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdaily_coll\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgetRegion\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtest_point\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mscale\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m30\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgetInfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     11\u001b[0m \u001b[0mpprint\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdaily_df\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     12\u001b[0m \u001b[1;31m# print('')\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\computedobject.py\u001b[0m in \u001b[0;36mgetInfo\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     96\u001b[0m       \u001b[0mThe\u001b[0m \u001b[0mobject\u001b[0m \u001b[0mcan\u001b[0m \u001b[0mevaluate\u001b[0m \u001b[0mto\u001b[0m \u001b[0manything\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     97\u001b[0m     \"\"\"\n\u001b[1;32m---> 98\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcomputeValue\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     99\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    100\u001b[0m   \u001b[1;32mdef\u001b[0m \u001b[0mencode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mencoder\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36mcomputeValue\u001b[1;34m(obj)\u001b[0m\n\u001b[0;32m    674\u001b[0m           \u001b[0mbody\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m{\u001b[0m\u001b[1;34m'expression'\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mserializer\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mencode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mfor_cloud_api\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    675\u001b[0m           \u001b[0mproject\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0m_get_projects_path\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 676\u001b[1;33m           prettyPrint=False))['result']\n\u001b[0m\u001b[0;32m    677\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    678\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\Miniconda3\\envs\\openet-testing\\lib\\site-packages\\ee\\data.py\u001b[0m in \u001b[0;36m_execute_cloud_call\u001b[1;34m(call, num_retries)\u001b[0m\n\u001b[0;32m    334\u001b[0m     \u001b[1;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mnum_retries\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    335\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mgoogleapiclient\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mHttpError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 336\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0m_translate_cloud_exception\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0me\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    337\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    338\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mEEException\u001b[0m: ImageCollection.getRegion: No bands in collection."
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            et_reference\n",
+      "2017-07-01      8.750780\n",
+      "2017-07-02      8.985552\n",
+      "2017-07-03      9.124432\n",
+      "2017-07-04      9.059896\n",
+      "2017-07-05      8.948065\n",
+      "2017-07-06      9.142155\n",
+      "2017-07-07      9.162968\n",
+      "2017-07-08      9.313854\n",
+      "2017-07-09      9.429415\n",
+      "2017-07-10      9.468430\n",
+      "2017-07-11      9.298468\n",
+      "2017-07-12      9.256013\n",
+      "2017-07-13      9.417242\n",
+      "2017-07-14      9.451098\n",
+      "2017-07-15      9.774522\n",
+      "2017-07-16      9.721956\n",
+      "2017-07-17      9.407862\n",
+      "2017-07-18      9.357646\n",
+      "2017-07-19      9.454647\n",
+      "2017-07-20      9.400379\n",
+      "2017-07-21      9.467653\n",
+      "2017-07-22      9.590332\n",
+      "2017-07-23      9.208388\n",
+      "2017-07-24      9.689781\n",
+      "2017-07-25      9.418958\n",
+      "2017-07-26      9.564580\n",
+      "2017-07-27      9.993216\n",
+      "2017-07-28     10.194906\n",
+      "2017-07-29      9.614853\n",
+      "2017-07-30      9.595454\n",
+      "2017-07-31      9.300901\n"
      ]
     }
    ],
@@ -224,9 +243,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            et_reference\n",
+      "2017-07-01    291.564392\n"
+     ]
+    }
+   ],
    "source": [
     "monthly_coll = model_obj.interpolate(\n",
     "    t_interval='monthly', \n",
@@ -248,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,9 +316,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYGCAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAHyAwADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5Tooor98P5PCiiigAooooAKKKKACiiigAooooAKKKKACiiigB69B9KWkXoPpS1mZhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAElFFFBmFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAqdfwp9MTr+FPqHuAUUUUgCiiigCnRRRXQdAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAPXoPpS0i9B9KWszMKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAkooooMwooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFTr+FPpidfwp9Q9wCiiikAUUUUAU6KKK6DoCiiigAooooAKKKKACiiigAooooAKKKKACiiigB69B9KWkXoPpS1mZhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAElFFFBmFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAqdfwp9MTr+FPqHuAUUUUgCiiigCnRRRXQdAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAPXoPpS0i9B9KWszMKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAkooooMwooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFTr+FPpidfwp9Q9wCiiikAUUUUAU6KKK6DoCiiigAooooAKKKKACiiigAooooAKKKKACiiigB69B9KWkXoPpS1mZhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAElFFFBmFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAqdfwp9MTr+FPqHuAUUUUgCiiigCnRRRXQdAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAPXoPpS0i9B9KWszMKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAkooooMwooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFTr+FPpidfwp9Q9wCiiikAUUUUAU6KKK6DoCiiigAooooAKKKKACiiigAooooAKKKKACiiigB69B9KWkXoPpS1mZhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAElFFFBmFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAqdfwp9MTr+FPqHuAUUUUgCiiigCnRRRXQdAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAPXoPpS0i9B9KWszMKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAkooooMwooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFTr+FPpidfwp9Q9wCiiikAUUUUAU6KKK6DoCiiigAooooAKKKKACiiigAooooAKKKKACiiigByscgU6mJ94U+oe5D3CiiikIKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigCSiiigzCiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAVOv4U+mJ1/Cn1D3AKKKKQBRRRQBToooroOgKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFT7wp9MT7wp9TLciW4UUUVIgooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAoopDIgOC4/OgBaKb5kf8Az0X86PMj/wCei/nQFmOopvmR/wDPRfzo8yP/AJ6L+dAWY6im+ZH/AM9F/OjzI/8Anov50BZjqKb5kf8Az0X86PMj/wCei/nQFmTUU3zov+eq/wDfVHnRf89V/wC+qCLMdRTfOi/56r/31R50X/PVf++qAsx1FN86L/nqv/fVHnRf89V/76oCzHUU3zov+eq/99UedF/z1X/vqgLMdRTfOi/56r/31R50X/PVf++qAsx1FN86L/nqv/fVHnRf89V/76oCzHUU3zov+eq/99UedF/z1X/vqgLMdRTfOi/56r/31R50X/PVf++qAsx1FN86L/nqv/fVHnRf89V/76oCzHUU3zov+eq/99UedF/z1X/vqgLMdRTfOi/56r/31R50X/PVf++qAsx1FN86L/nqv/fVHnRf89V/76oCzHp1/Cn1Ek0IPMq/99U7z4P+eyf99Coadwsx9FM8+D/nsn/fQo8+D/nsn/fQoswsx9FM8+D/AJ7J/wB9Cjz4P+eyf99CizCzK1FVvtE39/8ASj7RN/f/AErc6OVlmiq32ib+/wDpR9om/v8A6UByss0VW+0Tf3/0o+0Tf3/0oDlZZoqt9om/v/pR9om/v/pQHKyzRVb7RN/f/Sj7RN/f/SgOVlmiq32ib+/+lH2ib+/+lAcrLNFVvtE39/8ASj7RN/f/AEoDlZI11tYrs6H1pPtf/TP9ahJJOT3ooKsiYXmDny/1p32//pl/49VeilZMXLFlj7f/ANMv/HqPt/8A0y/8eqvRRZByRLH2/wD6Zf8Aj1H2/wD6Zf8Aj1V6KLIOSJY+3/8ATL/x6j7f/wBMv/Hqr0UWQckSx9v/AOmX/j1H2/8A6Zf+PVXoosg5Ilj7f/0y/wDHqPt//TL/AMeqvRRZByRLH2//AKZf+PUfb/8Apl/49VeiiyDkiWPt/wD0y/8AHqPt/wD0y/8AHqr0UWQckSx9v/6Zf+PUfb/+mX/j1V6KLIOSJY+3/wDTL/x6j7f/ANMv/Hqr0UWQckSx9v8A+mX/AI9R9v8A+mX/AI9VeiiyDkiWPt//AEy/8eo+3/8ATL/x6q9FFkHJEsfb/wDpl/49Srebhny/1qtTk6fjRZByRLH2v/pn+tH2v/pn+tQ0UWQckSb7X/0z/Wj7X/0z/WoaKLIOSJN9r/6Z/rR9r/6Z/rUNFFkHJEm+1/8ATP8AWj7X/wBM/wBahoosg5Ik32v/AKZ/rR9r/wCmf61DRRZByRJvtf8A0z/Wj7X/ANM/1qGiiyDkiTfa/wDpn+tH2v8A6Z/rUNFFkHJEm+1/9M/1qJjuYtjqaSiiyQ0ktgooopjCiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApydPxptOTp+NADqKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAjooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnJ0/Gm05On40AOooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigCOiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKcnT8abTk6fjQA6iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApydPxptOTp+NADqKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAjooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnJ0/Gm05On40AOooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigCOiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKcnT8abTk6fjQA6iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApydPxptOTp+NADqKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAjooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnJ0/Gm05On40AOooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigCOiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKcnT8abTk6fjQA6iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApydPxptOTp+NADqKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAjooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnJ0/Gm05On40AOooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigCOiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKcnT8abTk6fjQA6iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApydPxptOTp+NADqKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAjooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnJ0/Gm05CAOTQA6iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKAI6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAevQfSlpF6D6UtABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRVD7bc/8APX/x0Ufbbn/nr/46KvkZfIy/RVD7bc/89f8Ax0Ufbbn/AJ6/+OijkYcjL9FUPttz/wA9f/HRR9tuf+ev/joo5GHIy/RVD7bc/wDPX/x0Ufbbn/nr/wCOijkYcjL9FUPttz/z1/8AHRR9tuf+ev8A46KORhyMv0VQ+23P/PX/AMdFH225/wCev/joo5GHIy/RVD7bc/8APX/x0Ufbbn/nr/46KORhyMv0VQ+23P8Az1/8dFH225/56/8Ajoo5GHIy/RVD7bc/89f/AB0Ufbbn/nr/AOOijkYcjL9FUPttz/z1/wDHRR9tuf8Anr/46KORhyMv0VQ+23P/AD1/8dFH225/56/+OijkYcjL9FUPttz/AM9f/HRTWv7sHAl/8dFHIxqnJmjRWb9vu/8Anr/46KPt93/z1/8AHRRyMPZSNKis37fd/wDPX/x0Ufb7v/nr/wCOijkYeykWPtsX91vyo+2xf3W/KqtFXyRHyRLX22L+635UfbYv7rflVWijkiHJEtfbYv7rflR9ti/ut+VVaKOSIckS19ti/ut+VH22L+635VVoo5IhyRLX22L+635UfbYv7rflVWijkiHJEtfbYv7rflR9ti/ut+VVaKOSIckS19ti/ut+VH22L+635VVoo5IhyRLX22L+635UfbYv7rflVWijkiHJEtC9iJxtb8qX7VH/AHW/KqqfeFPqXFIOSJP9qj/ut+VH2qP+635VBRS5UHJEn+1R/wB1vyo+1R/3W/KoKKOVByRJ/tUf91vyo+1R/wB1vyqCijlQckSf7VH/AHW/KoKKKErFKKWwUUUUxhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQA1+n402nP0/Gm1cdgCiiimAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFMf7xp9Mf7xoHHcSiiigsKKKKAJKKKKDMKKKKACiiigAooooAKKKKACiiigAooooAKKKKAFT7wp9MT7wp9TLcAoooqQCiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAa/T8abTn6fjTauOwBRRRTAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACmP8AeNPpj/eNA47iUUUUFhRRRQBJRRRQZhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAqfeFPpifeFPqZbgFFFFSAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFADX6fjTac/T8abVx2AKKKKYBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUx/vGn0x/vGgcdxKKKKCwooooAkooooMwooooAKKKKACiiigAooooAKKKKACiiigAooooAVPvCn0xPvCn1MtwCiiipAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigBr9PxptOfp+NNq47AFFFFMAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKY/3jT6Y/3jQOO4lFFFBYUUUUASUUUUGYUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAKv3qfkHoajp0fepaAdRRRUgFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQA1+n402nP0/Gm1cdgCiiimAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFMf7xp9Mf7xoHHcSiiigsKKKKAJKKKKDMKKKKACiiigAooooAKKKKACiiigAooooAKKKKACnR96KKT2AdRRRUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQA1+n402iirjsAUUUUwCiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigApj/eNFFA47iUUUUFhRRRQB/9k=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "image_url = ee.Image(monthly_coll.select(['et_reference']).sum())\\\n",
     "    .reproject(crs=study_crs, scale=100)\\\n",
@@ -330,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.6.10"
   },
   "pycharm": {
    "stem_cell": {

--- a/openet/ssebop/__init__.py
+++ b/openet/ssebop/__init__.py
@@ -2,6 +2,6 @@ from .image import Image
 from .collection import Collection
 from . import interpolate
 
-__version__ = "0.1.6"
+__version__ = "0.1.51"
 
 MODEL_NAME = 'SSEBOP'

--- a/openet/ssebop/__init__.py
+++ b/openet/ssebop/__init__.py
@@ -2,6 +2,6 @@ from .image import Image
 from .collection import Collection
 from . import interpolate
 
-__version__ = "0.1.51"
+__version__ = "0.1.6"
 
 MODEL_NAME = 'SSEBOP'

--- a/openet/ssebop/__init__.py
+++ b/openet/ssebop/__init__.py
@@ -2,6 +2,6 @@ from .image import Image
 from .collection import Collection
 from . import interpolate
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 MODEL_NAME = 'SSEBOP'

--- a/openet/ssebop/collection.py
+++ b/openet/ssebop/collection.py
@@ -44,6 +44,7 @@ class Collection():
             et_reference_band=None,
             et_reference_factor=None,
             et_reference_resample=None,
+            et_reference_date_type=None,
             filter_args=None,
             model_args=None,
             # model_args={'et_reference_source': 'IDAHO_EPSCOR/GRIDMET',
@@ -116,6 +117,7 @@ class Collection():
         self.et_reference_band = et_reference_band
         self.et_reference_factor = et_reference_factor
         self.et_reference_resample = et_reference_resample
+        # self.et_reference_date_type = et_reference_date_type
 
         # Check reference ET parameters
         if et_reference_factor and not utils.is_number(et_reference_factor):

--- a/openet/ssebop/collection.py
+++ b/openet/ssebop/collection.py
@@ -117,7 +117,7 @@ class Collection():
         self.et_reference_band = et_reference_band
         self.et_reference_factor = et_reference_factor
         self.et_reference_resample = et_reference_resample
-        # self.et_reference_date_type = et_reference_date_type
+        self.et_reference_date_type = et_reference_date_type
 
         # Check reference ET parameters
         if et_reference_factor and not utils.is_number(et_reference_factor):
@@ -128,6 +128,10 @@ class Collection():
         if (et_reference_resample and
                 et_reference_resample.lower() not in et_reference_resample_methods):
             raise ValueError('unsupported et_reference_resample method')
+        et_reference_date_type_methods = ['doy', 'daily']
+        if (et_reference_date_type and
+                et_reference_date_type.lower() not in et_reference_date_type_methods):
+            raise ValueError('unsupported et_reference_date_type method')
 
         # Set/update the reference ET parameters in model_args if they were set in init()
         if self.et_reference_source:
@@ -138,6 +142,8 @@ class Collection():
             self.model_args['et_reference_factor'] = self.et_reference_factor
         if self.et_reference_resample:
             self.model_args['et_reference_resample'] = self.et_reference_resample
+        if self.et_reference_date_type:
+            self.model_args['et_reference_date_type'] = self.et_reference_date_type
 
         # Model specific variables that can be interpolated to a daily timestep
         # CGM - Should this be specified in the interpolation method instead?

--- a/openet/ssebop/image.py
+++ b/openet/ssebop/image.py
@@ -347,10 +347,11 @@ class Image():
             et_reference_img = ee.Image.constant(self.et_reference_source)
         elif type(self.et_reference_source) is str:
             if self.et_reference_date_type == 'DOY':
+                # Assume a string source is an image collection ID (not an image ID) and only has DOY properties
                 def gridmet_median_v1_replace_daily(image):
                     """Mapping function to get daily time_start and system:index
 
-                    Returns the doy-based gridmet with daily time properties
+                    Returns the doy-based reference et with daily time properties from GRIDMET
                     """
                     image_date = ee.Algorithms.Date(image.get("system:time_start"))
                     doy = ee.Number(image_date.getRelative('day', 'year')).add(1).double()

--- a/openet/ssebop/interpolate.py
+++ b/openet/ssebop/interpolate.py
@@ -180,7 +180,7 @@ def from_scene_et_fraction(scene_coll, start_date, end_date, variables,
             # Note, the collection and band that are used are important as
             #   long as they are daily and available for the time period
             daily_et_ref_coll = ee.ImageCollection(('IDAHO_EPSCOR/GRIDMET')) \
-                .filterDate(start_date, end_date).select(['pet'])\
+                .filterDate(start_date, end_date).select([et_reference_band])\
                 .map(doy_image)
     # elif isinstance(et_reference_source, computedobject.ComputedObject):
     #     # Interpret computed objects as image collections

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -1559,7 +1559,7 @@ def test_Image_et_reference_source(source, band, factor, xy, expected,
          'etr', TEST_POINT, 10.2452],
         # Check that date_type parameter is not case sensitive
         ['DOY', 'projects/usgs-ssebop/pet/gridmet_median_v1',
-         'etr', TEST_POINT, 10.2452],
+         'eto', TEST_POINT, 7.7345],
         # None or "daily" is the default behavior of pulling the target date
         [None, 'IDAHO_EPSCOR/GRIDMET', 'etr', TEST_POINT, 9.5730],
         ['daily', 'IDAHO_EPSCOR/GRIDMET', 'etr', TEST_POINT, 9.5730],

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -1562,6 +1562,7 @@ def test_Image_et_reference_source(source, band, factor, xy, expected,
          'etr', TEST_POINT, 10.2452],
         # None or "daily" is the default behavior of pulling the target date
         [None, 'IDAHO_EPSCOR/GRIDMET', 'etr', TEST_POINT, 9.5730],
+        ['daily', 'IDAHO_EPSCOR/GRIDMET', 'etr', TEST_POINT, 9.5730],
     ]
 )
 def test_Image_et_reference_date_type(date_type, source, band, xy, expected,

--- a/openet/ssebop/tests/test_c_image.py
+++ b/openet/ssebop/tests/test_c_image.py
@@ -73,6 +73,7 @@ def default_image_args(lst=305, ndvi=0.8,
                        et_reference_band='etr',
                        et_reference_factor=1,
                        et_reference_resample='nearest',
+                       et_reference_date_type=None,
                        dt_source=18,
                        elev_source=67,
                        elr_flag=False,
@@ -90,6 +91,7 @@ def default_image_args(lst=305, ndvi=0.8,
         'et_reference_band': et_reference_band,
         'et_reference_factor': et_reference_factor,
         'et_reference_resample': et_reference_resample,
+        'et_reference_date_type': et_reference_date_type,
         'dt_source': dt_source,
         'elev_source': elev_source,
         'elr_flag': elr_flag,
@@ -109,6 +111,7 @@ def default_image_obj(lst=305, ndvi=0.8,
                       et_reference_band='etr',
                       et_reference_factor=1,
                       et_reference_resample='nearest',
+                      et_reference_date_type=None,
                       dt_source=18,
                       elev_source=67,
                       elr_flag=False,
@@ -126,6 +129,7 @@ def default_image_obj(lst=305, ndvi=0.8,
         et_reference_band=et_reference_band,
         et_reference_factor=et_reference_factor,
         et_reference_resample=et_reference_resample,
+        et_reference_date_type=et_reference_date_type,
         dt_source=dt_source,
         elev_source=elev_source,
         elr_flag=elr_flag,
@@ -145,6 +149,7 @@ def test_Image_init_default_parameters():
     assert m.et_reference_band == None
     assert m.et_reference_factor == None
     assert m.et_reference_resample == None
+    assert m.et_reference_date_type == None
     assert m._dt_source == 'DAYMET_MEDIAN_V2'
     assert m._elev_source == None
     assert m._tcorr_source == 'DYNAMIC'
@@ -318,7 +323,7 @@ def test_Image_dt_source_constant(dt_source, xy, expected, tol=0.001):
     [
         ['CIMIS', 18, '2017-07-16', [-122.1622, 39.1968], 17.1013],
         ['DAYMET', 18, '2017-07-16', [-122.1622, 39.1968], 13.5525],
-        ['GRIDMET', 18, '2017-07-16', [-122.1622, 39.1968], 18.1700],
+        ['GRIDMET', 18, '2017-07-16', [-122.1622, 39.1968], 18.1588],
         # ['GRIDMET', 18, '2017-07-16', [-122.1622, 39.1968], 18.1711],
         # ['CIMIS', 67, SCENE_DATE, TEST_POINT, 17.10647],
         # ['DAYMET', 67, SCENE_DATE, TEST_POINT, 12.99047],
@@ -1547,10 +1552,37 @@ def test_Image_et_reference_source(source, band, factor, xy, expected,
     assert abs(output['et_reference'] - expected) <= tol
 
 
+@pytest.mark.parametrize(
+    'date_type, source, band, xy, expected',
+    [
+        ['doy', 'projects/usgs-ssebop/pet/gridmet_median_v1',
+         'etr', TEST_POINT, 10.2452],
+        # Check that date_type parameter is not case sensitive
+        ['DOY', 'projects/usgs-ssebop/pet/gridmet_median_v1',
+         'etr', TEST_POINT, 10.2452],
+        # None or "daily" is the default behavior of pulling the target date
+        [None, 'IDAHO_EPSCOR/GRIDMET', 'etr', TEST_POINT, 9.5730],
+    ]
+)
+def test_Image_et_reference_date_type(date_type, source, band, xy, expected,
+                                      tol=0.001):
+    """Test if the date_type parameter works"""
+    output = utils.point_image_value(default_image_obj(
+        et_reference_source=source, et_reference_band=band,
+        et_reference_date_type=date_type).et_reference, xy)
+    assert abs(output['et_reference'] - expected) <= tol
+
+
+# TODO: Write a test to check that an exception is raise if the source collection
+#   doesn't have a DOY property when the date type is "DOY"
+
+
 # TODO: Exception should be raised if source is not named like a collection
-# def test_Image_et_reference_source_exception():
-#     with pytest.raises(ValueError):
-#         utils.getinfo(default_image_obj(et_reference_source='DEADBEEF').et_reference)
+#   Currently an exception is only raise if not a string or number
+def test_Image_et_reference_source_exception():
+    with pytest.raises(ValueError):
+        utils.getinfo(default_image_obj(
+            et_reference_source=ee.Image.constant(10)).et_reference)
 
 
 def test_Image_et_properties():

--- a/openet/ssebop/tests/test_d_collection.py
+++ b/openet/ssebop/tests/test_d_collection.py
@@ -31,6 +31,7 @@ default_coll_args = {
     'et_reference_band': 'etr',
     'et_reference_factor': 0.85,
     'et_reference_resample': 'nearest',
+    'et_reference_date_type': None,
     'model_args': {},
     'filter_args': {},
 }
@@ -55,6 +56,7 @@ def test_Collection_init_default_parameters():
     del args['et_reference_band']
     del args['et_reference_factor']
     del args['et_reference_resample']
+    del args['et_reference_date_type']
     del args['variables']
 
     m = ssebop.Collection(**args)
@@ -63,6 +65,7 @@ def test_Collection_init_default_parameters():
     assert m.et_reference_band == None
     assert m.et_reference_factor == None
     assert m.et_reference_resample == None
+    assert m.et_reference_date_type == None
     assert m.cloud_cover_max == 70
     assert m.model_args == {}
     assert m.filter_args == {}

--- a/openet/ssebop/tests/test_d_interpolate.py
+++ b/openet/ssebop/tests/test_d_interpolate.py
@@ -166,3 +166,42 @@ def test_from_scene_et_fraction_monthly_et_reference_resample(tol=0.0001):
     # assert abs(output['et_reference']['2017-07-01'] - 303.622559) <= tol
     # assert abs(output['et']['2017-07-01'] - (303.622559 * 0.4)) <= tol
     assert output['count']['2017-07-01'] == 3
+
+
+# CGM - Test out using a reference ET climatology
+def test_from_scene_et_fraction_daily_et_reference_date_type_doy(tol=0.01):
+    output_coll = interpolate.from_scene_et_fraction(
+        scene_coll(['et_fraction', 'ndvi', 'time', 'mask']),
+        start_date='2017-07-01', end_date='2017-08-01',
+        variables=['et_reference'],
+        interp_args={'interp_method': 'linear', 'interp_days': 32},
+        model_args={'et_reference_source': 'projects/usgs-ssebop/pet/gridmet_median_v1',
+                    'et_reference_band': 'etr',
+                    'et_reference_factor': 1.0,
+                    'et_reference_resample': 'nearest',
+                    'et_reference_date_type': 'doy'},
+        t_interval='daily')
+
+    TEST_POINT = (-121.5265, 38.7399)
+    output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
+    # pprint.pprint(output)
+    assert abs(output['et_reference']['2017-07-01'] - 8.75) <= tol
+
+
+def test_from_scene_et_fraction_monthly_et_reference_date_type_doy(tol=0.01):
+    output_coll = interpolate.from_scene_et_fraction(
+        scene_coll(['et_fraction', 'ndvi', 'time', 'mask']),
+        start_date='2017-07-01', end_date='2017-08-01',
+        variables=['et_reference'],
+        interp_args={'interp_method': 'linear', 'interp_days': 32},
+        model_args={'et_reference_source': 'projects/usgs-ssebop/pet/gridmet_median_v1',
+                    'et_reference_band': 'etr',
+                    'et_reference_factor': 1.0,
+                    'et_reference_resample': 'nearest',
+                    'et_reference_date_type': 'doy'},
+        t_interval='monthly')
+
+    TEST_POINT = (-121.5265, 38.7399)
+    output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
+    assert abs(output['et_reference']['2017-07-01'] - 291.56) <= tol
+

--- a/openet/ssebop/tests/test_d_interpolate.py
+++ b/openet/ssebop/tests/test_d_interpolate.py
@@ -91,8 +91,8 @@ def test_from_scene_et_fraction_monthly_values(tol=0.0001):
     output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
     assert abs(output['ndvi']['2017-07-01'] - 0.6) <= tol
     assert abs(output['et_fraction']['2017-07-01'] - 0.4) <= tol
-    assert abs(output['et_reference']['2017-07-01'] - 303.4) <= tol
-    assert abs(output['et']['2017-07-01'] - (303.4 * 0.4)) <= tol
+    assert abs(output['et_reference']['2017-07-01'] - 310.3) <= tol
+    assert abs(output['et']['2017-07-01'] - (310.3 * 0.4)) <= tol
     # assert abs(output['et_reference']['2017-07-01'] - 303.622559) <= tol
     # assert abs(output['et']['2017-07-01'] - (303.622559 * 0.4)) <= tol
     assert output['count']['2017-07-01'] == 3
@@ -114,8 +114,8 @@ def test_from_scene_et_fraction_custom_values(tol=0.0001):
     output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
     assert abs(output['ndvi']['2017-07-01'] - 0.6) <= tol
     assert abs(output['et_fraction']['2017-07-01'] - 0.4) <= tol
-    assert abs(output['et_reference']['2017-07-01'] - 303.4) <= tol
-    assert abs(output['et']['2017-07-01'] - (303.4 * 0.4)) <= tol
+    assert abs(output['et_reference']['2017-07-01'] - 310.3) <= tol
+    assert abs(output['et']['2017-07-01'] - (310.3 * 0.4)) <= tol
     # assert abs(output['et_reference']['2017-07-01'] - 303.622559) <= tol
     # assert abs(output['et']['2017-07-01'] - (303.622559 * 0.4)) <= tol
     assert output['count']['2017-07-01'] == 3
@@ -137,8 +137,8 @@ def test_from_scene_et_fraction_monthly_et_reference_factor(tol=0.0001):
     output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
     assert abs(output['ndvi']['2017-07-01'] - 0.6) <= tol
     assert abs(output['et_fraction']['2017-07-01'] - 0.4) <= tol
-    assert abs(output['et_reference']['2017-07-01'] - 303.399994 * 0.5) <= tol
-    assert abs(output['et']['2017-07-01'] - (303.399994 * 0.5 * 0.4)) <= tol
+    assert abs(output['et_reference']['2017-07-01'] - 310.3 * 0.5) <= tol
+    assert abs(output['et']['2017-07-01'] - (310.3 * 0.5 * 0.4)) <= tol
     # assert abs(output['et_reference']['2017-07-01'] - 303.622559 * 0.5) <= tol
     # assert abs(output['et']['2017-07-01'] - (303.622559 * 0.5 * 0.4)) <= tol
     assert output['count']['2017-07-01'] == 3
@@ -161,8 +161,8 @@ def test_from_scene_et_fraction_monthly_et_reference_resample(tol=0.0001):
     output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
     assert abs(output['ndvi']['2017-07-01'] - 0.6) <= tol
     assert abs(output['et_fraction']['2017-07-01'] - 0.4) <= tol
-    assert abs(output['et_reference']['2017-07-01'] - 303.4) <= tol
-    assert abs(output['et']['2017-07-01'] - (303.4 * 0.4)) <= tol
+    assert abs(output['et_reference']['2017-07-01'] - 310.3) <= tol
+    assert abs(output['et']['2017-07-01'] - (310.3 * 0.4)) <= tol
     # assert abs(output['et_reference']['2017-07-01'] - 303.622559) <= tol
     # assert abs(output['et']['2017-07-01'] - (303.622559 * 0.4)) <= tol
     assert output['count']['2017-07-01'] == 3

--- a/openet/ssebop/tests/test_d_interpolate.py
+++ b/openet/ssebop/tests/test_d_interpolate.py
@@ -168,8 +168,8 @@ def test_from_scene_et_fraction_monthly_et_reference_resample(tol=0.0001):
     assert output['count']['2017-07-01'] == 3
 
 
-# CGM - Test out using a reference ET climatology
 def test_from_scene_et_fraction_daily_et_reference_date_type_doy(tol=0.01):
+    """Test interpolating a daily collection using a reference ET climatology"""
     output_coll = interpolate.from_scene_et_fraction(
         scene_coll(['et_fraction', 'ndvi', 'time', 'mask']),
         start_date='2017-07-01', end_date='2017-08-01',
@@ -189,6 +189,7 @@ def test_from_scene_et_fraction_daily_et_reference_date_type_doy(tol=0.01):
 
 
 def test_from_scene_et_fraction_monthly_et_reference_date_type_doy(tol=0.01):
+    """Test interpolating a monthly collection using a reference ET climatology"""
     output_coll = interpolate.from_scene_et_fraction(
         scene_coll(['et_fraction', 'ndvi', 'time', 'mask']),
         start_date='2017-07-01', end_date='2017-08-01',
@@ -204,4 +205,3 @@ def test_from_scene_et_fraction_monthly_et_reference_date_type_doy(tol=0.01):
     TEST_POINT = (-121.5265, 38.7399)
     output = utils.point_coll_value(output_coll, TEST_POINT, scale=10)
     assert abs(output['et_reference']['2017-07-01'] - 291.56) <= tol
-

--- a/tcorr_gridded/ini/tcorr_daymet_v4_LCRB.ini
+++ b/tcorr_gridded/ini/tcorr_daymet_v4_LCRB.ini
@@ -1,0 +1,42 @@
+# DAYMET v4 Mean Gridded Tcorr Export Input File
+
+[INPUTS]
+# Date range
+# Start/end date will not be read in cron mode
+start_date = 2010-01-01
+end_date = 2010-12-31
+
+
+# Study area feature collection (mandatory)
+# Script will make an inList filter call if property/features parameters are set
+study_area_coll = TIGER/2018/States
+study_area_property = STUSPS
+study_area_features = CONUS
+#study_area_features = AZ, CA, CO, ID, MT, NM, NV, OR, UT, WA, WY, TX, NE, KS, SD, ND, OK
+
+# Comma separated string of EE Collection IDs
+collections = LANDSAT/LC08/C02/T1_L2, LANDSAT/LE07/C02/T1_L2, LANDSAT/LT05/C02/T1_L2
+
+# Maximum ACCA cloud cover percentage (0-100)
+cloud_cover = 70
+
+# Comma separated string of Landsat WRS2 tiles (i.e. 'p045r043, p045r033'])
+# If not set, use all available WRS2 tiles that intersect the study area
+wrs2_tiles = ‘p034r035, p034r036, p034r037, p034r038, p035r035, p035r036, p035r037, p035r038, p036r035, p036r036, p036r037, p036r038, p037r034, p037r035, p037r036, p037r037, p037r038, p038r034, p038r035, p038r036, p038r037, p038r038, p039r033, p039r034, p039r035, p039r036, p039r037, p040r033, p040r034, p040r035’
+#wrs2_tiles = 'p033r039'
+
+[EXPORT]
+# Mimic the tmax source collection naming for the tcorr collection
+export_coll = projects/earthengine-legacy/assets/projects/usgs-ssebop/tcorr_gridded/c02/daymet_v4_mean_1981_2010_elr
+
+# mgrs_tiles = 10S, 10T, 11S
+# utm_zones = 10, 11, 12, 13, 14, 15
+
+mgrs_ftr_coll = projects/earthengine-legacy/assets/projects/openet/mgrs/conus_gridmet/zones
+# mgrs_ftr_coll = projects/earthengine-legacy/assets/projects/openet/mgrs/conus_gridmet/tiles
+
+
+[SSEBOP]
+tmax_source = projects/earthengine-legacy/assets/projects/usgs-ssebop/tmax/daymet_v4_mean_1981_2010_elr
+
+tcorr_source = GRIDDED_COLD


### PR DESCRIPTION
@cgmorton - can you review this merge request when you get time?

The feature additions in this branch include ability to use string IDs for reference ET that has day-of-year properties without a daily system:time_start property. Not the most elegant solution but works for some custom image collections.

Important Note: For using with export INI config files we'll need to probably add **et_reference_date_type = DOY** variable flag like this:

et_reference_source = projects/usgs-ssebop/pet/gridmet_median_v1
et_reference_band = etr
et_reference_factor = 0.85
et_reference_resample = nearest
// Date choices: DOY or comment this out
et_reference_date_type = DOY